### PR TITLE
[feat] 1차 세미나 선택 과제 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+.idea/

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,8 @@ repositories {
 dependencies {
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.0'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 test {

--- a/src/main/java/org/sopt/week1/Diary.java
+++ b/src/main/java/org/sopt/week1/Diary.java
@@ -1,13 +1,18 @@
 package org.sopt.week1;
 
 
+import java.io.Serializable;
 import java.time.LocalDate;
 
-public class Diary {
+public class Diary implements Serializable {
+    private static final long serialVersionUID = 1L;
     private Long id;
     private String body;
     private LocalDate updatedAt;
     private int patchCount;
+
+    public Diary() {
+    }
 
     private Diary(Long id, String body) {
         this.id = id;

--- a/src/main/java/org/sopt/week1/Diary.java
+++ b/src/main/java/org/sopt/week1/Diary.java
@@ -1,12 +1,18 @@
 package org.sopt.week1;
 
+
+import java.time.LocalDate;
+
 public class Diary {
     private Long id;
-    private final String body;
+    private String body;
+    private LocalDate updatedAt;
+    private int patchCount;
 
     private Diary(Long id, String body) {
         this.id = id;
         this.body = body;
+        this.patchCount = 0;
     }
 
     public Long getId() {
@@ -17,7 +23,31 @@ public class Diary {
         return body;
     }
 
+    public LocalDate getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public int getPatchCount() {
+        return patchCount;
+    }
+
     public static Diary of(Long id, String body) {
         return new Diary(id, body);
+    }
+
+    public void updateBody(String body) {
+        this.body = body;
+    }
+
+    public void updateUpdatedAt() {
+        updatedAt = LocalDate.now();
+    }
+
+    public void incrementPatchCount() {
+        patchCount++;
+    }
+
+    public void resetPatchCount() {
+        patchCount = 1;
     }
 }

--- a/src/main/java/org/sopt/week1/DiaryController.java
+++ b/src/main/java/org/sopt/week1/DiaryController.java
@@ -41,6 +41,15 @@ public class DiaryController {
         diaryService.deleteDiary(Long.parseLong(id));
     }
 
+    final List<Diary> getTrashList() {
+        return diaryService.getTrashList();
+    }
+
+    final void restore(final String id) {
+        validateType(id);
+        diaryService.restoreDiary(Long.parseLong(id));
+    }
+
     private void validateBody(String body) {
         if (body.length() > 30) {
             throw new InvalidInputException("일기 글자수는 30글자를 넘을 수 없습니다.");

--- a/src/main/java/org/sopt/week1/DiaryRepository.java
+++ b/src/main/java/org/sopt/week1/DiaryRepository.java
@@ -1,7 +1,5 @@
 package org.sopt.week1;
 
-import org.sopt.week1.Main.UI.InvalidInputException;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -9,21 +7,27 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class DiaryRepository {
-    private final Map<Long, String> storage = new ConcurrentHashMap<>();
-    private final Map<Long, String> trash = new ConcurrentHashMap<>();
+    private final Map<Long, Diary> storage = new ConcurrentHashMap<>();
+    private final Map<Long, Diary> trash = new ConcurrentHashMap<>();
     private final AtomicLong numbering = new AtomicLong();
 
     void save(final Diary diary) {
         final long id = numbering.addAndGet(1);
 
-        storage.put(id, diary.getBody());
+        storage.put(id, diary);
+    }
+
+    public Diary findById(Long id) {
+        return storage.get(id);
     }
 
     List<Diary> findAll() {
         List<Diary> diaryList = new ArrayList<>();
 
         for (long index = 1; index <= numbering.get(); index++) {
-            final String body = storage.get(index);
+            final String body = storage.get(index).getBody();
+
+            System.out.println(storage.get(index).getBody() + storage.get(index).getUpdatedAt() + storage.get(index).getPatchCount());
 
             if (body != null) {
                 diaryList.add(Diary.of(index, body));
@@ -37,17 +41,17 @@ public class DiaryRepository {
         List<Diary> trashList = new ArrayList<>();
 
         // trash의 각 항목을 돌면서 리스트에 추가함
-        for (Map.Entry<Long, String> entry : trash.entrySet()) {
+        for (Map.Entry<Long, Diary> entry : trash.entrySet()) {
             Long id = entry.getKey();
-            String body = entry.getValue();
+            String body = entry.getValue().getBody();
             trashList.add(Diary.of(id, body));
         }
 
         return trashList;
     }
 
-    public void patch(Long id, String body) {
-        storage.put(id, body);
+    public void patch(Long id, Diary diary) {
+        storage.put(id, diary);
     }
 
     public void delete(Long id) {

--- a/src/main/java/org/sopt/week1/DiaryRepository.java
+++ b/src/main/java/org/sopt/week1/DiaryRepository.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class DiaryRepository {
     private final Map<Long, String> storage = new ConcurrentHashMap<>();
+    private final Map<Long, String> trash = new ConcurrentHashMap<>();
     private final AtomicLong numbering = new AtomicLong();
 
     void save(final Diary diary) {
@@ -32,15 +33,38 @@ public class DiaryRepository {
         return diaryList;
     }
 
+    public List<Diary> findAllInTrash() {
+        List<Diary> trashList = new ArrayList<>();
+
+        // trash의 각 항목을 돌면서 리스트에 추가함
+        for (Map.Entry<Long, String> entry : trash.entrySet()) {
+            Long id = entry.getKey();
+            String body = entry.getValue();
+            trashList.add(Diary.of(id, body));
+        }
+
+        return trashList;
+    }
+
     public void patch(Long id, String body) {
         storage.put(id, body);
     }
 
     public void delete(Long id) {
+        trash.put(id, storage.get(id));
         storage.remove(id);
+    }
+
+    public void restore(Long id) {
+        storage.put(id, trash.get(id));
+        trash.remove(id);
     }
 
     public boolean existsById(Long id) {
         return storage.containsKey(id);
+    }
+
+    public boolean existsInTrashById(Long id) {
+        return trash.containsKey(id);
     }
 }

--- a/src/main/java/org/sopt/week1/DiaryRepository.java
+++ b/src/main/java/org/sopt/week1/DiaryRepository.java
@@ -1,5 +1,11 @@
 package org.sopt.week1;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -7,14 +13,29 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class DiaryRepository {
+    private static final String STORAGE_FILE = "storage.json";
+    private static final String TRASH_FILE = "trash.json";
+    private static final String NUMBERING_FILE = "numbering.json";
+
     private final Map<Long, Diary> storage = new ConcurrentHashMap<>();
     private final Map<Long, Diary> trash = new ConcurrentHashMap<>();
     private final AtomicLong numbering = new AtomicLong();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
-    void save(final Diary diary) {
+    public DiaryRepository() {
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        loadDiaries();
+        loadTrash();
+        loadNumbering();
+    }
+
+    void save(final String body) {
         final long id = numbering.addAndGet(1);
 
-        storage.put(id, diary);
+        storage.put(id, Diary.of(id, body));
+        saveDiaries();
+        saveNumbering();
     }
 
     public Diary findById(Long id) {
@@ -25,12 +46,10 @@ public class DiaryRepository {
         List<Diary> diaryList = new ArrayList<>();
 
         for (long index = 1; index <= numbering.get(); index++) {
-            final String body = storage.get(index).getBody();
+            Diary diary = storage.get(index);
 
-            System.out.println(storage.get(index).getBody() + storage.get(index).getUpdatedAt() + storage.get(index).getPatchCount());
-
-            if (body != null) {
-                diaryList.add(Diary.of(index, body));
+            if (diary != null) {
+                diaryList.add(diary);
             }
         }
 
@@ -42,9 +61,7 @@ public class DiaryRepository {
 
         // trash의 각 항목을 돌면서 리스트에 추가함
         for (Map.Entry<Long, Diary> entry : trash.entrySet()) {
-            Long id = entry.getKey();
-            String body = entry.getValue().getBody();
-            trashList.add(Diary.of(id, body));
+            trashList.add(entry.getValue());
         }
 
         return trashList;
@@ -52,16 +69,21 @@ public class DiaryRepository {
 
     public void patch(Long id, Diary diary) {
         storage.put(id, diary);
+        saveDiaries();
     }
 
     public void delete(Long id) {
         trash.put(id, storage.get(id));
         storage.remove(id);
+        saveDiaries();
+        saveTrash();
     }
 
     public void restore(Long id) {
         storage.put(id, trash.get(id));
         trash.remove(id);
+        saveDiaries();
+        saveTrash();
     }
 
     public boolean existsById(Long id) {
@@ -70,5 +92,56 @@ public class DiaryRepository {
 
     public boolean existsInTrashById(Long id) {
         return trash.containsKey(id);
+    }
+
+    private void saveDiaries() {
+        try {
+            objectMapper.writeValue(new File(STORAGE_FILE), storage);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void loadDiaries() {
+        try {
+            Map<Long, Diary> loadedStorage = objectMapper.readValue(new File(STORAGE_FILE), new TypeReference<Map<Long, Diary>>() {});
+            storage.putAll(loadedStorage);
+        } catch (IOException e) {
+            System.out.println("기존 일기 데이터를 불러오지 못했습니다. 새로 시작합니다.");
+        }
+    }
+
+    private void saveTrash() {
+        try {
+            objectMapper.writeValue(new File(TRASH_FILE), trash);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void loadTrash() {
+        try {
+            Map<Long, Diary> loadedTrash = objectMapper.readValue(new File(TRASH_FILE), new TypeReference<Map<Long, Diary>>() {});
+            trash.putAll(loadedTrash);
+        } catch (IOException e) {
+            System.out.println("기존 휴지통 데이터를 불러오지 못했습니다. 새로 시작합니다.");
+        }
+    }
+
+    private void saveNumbering() {
+        try {
+            objectMapper.writeValue(new File(NUMBERING_FILE), numbering);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void loadNumbering() {
+        try {
+            AtomicLong loadedNumbering = objectMapper.readValue(new File(NUMBERING_FILE), AtomicLong.class);
+            numbering.set(loadedNumbering.get());
+        } catch (IOException e) {
+            System.out.println("기존 번호 데이터를 불러오지 못했습니다. 새로 시작합니다.");
+        }
     }
 }

--- a/src/main/java/org/sopt/week1/DiaryService.java
+++ b/src/main/java/org/sopt/week1/DiaryService.java
@@ -26,6 +26,15 @@ public class DiaryService {
         diaryRepository.delete(id);
     }
 
+    public List<Diary> getTrashList() {
+        return diaryRepository.findAllInTrash();
+    }
+
+    public void restoreDiary(Long id) {
+        validateExist(id);
+        diaryRepository.restore(id);
+    }
+
     private void validateExist(Long id) {
         if(!diaryRepository.existsById(id)) {
             throw new InvalidInputException("존재하지 않는 id 값입니다.");

--- a/src/main/java/org/sopt/week1/DiaryService.java
+++ b/src/main/java/org/sopt/week1/DiaryService.java
@@ -1,8 +1,11 @@
 package org.sopt.week1;
 
 import org.sopt.week1.Main.UI.InvalidInputException;
+import org.sopt.week1.Main.UI.LimitExceededException;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 
 public class DiaryService {
     private final DiaryRepository diaryRepository = new DiaryRepository();
@@ -18,7 +21,10 @@ public class DiaryService {
 
     public void patchDiary(Long id, String body) {
         validateExist(id);
-        diaryRepository.patch(id, body);
+        Diary diary = diaryRepository.findById(id);
+        updatePatchCountAndDate(diary);
+        diary.updateBody(body); //일기 내용 수정
+        diaryRepository.patch(id, diary);
     }
 
     public void deleteDiary(Long id) {
@@ -44,6 +50,18 @@ public class DiaryService {
     private void validateExistInTrash(Long id) {
         if(!diaryRepository.existsInTrashById(id)) {
             throw new InvalidInputException("존재하지 않는 id 값입니다.");
+        }
+    }
+
+    private void updatePatchCountAndDate(Diary diary) {
+        if (Objects.equals(diary.getUpdatedAt(), LocalDate.now())) { //같은 날 수정하는 경우
+            if (diary.getPatchCount() == 2) {
+                throw new LimitExceededException("하루에 일기를 2번 이상 수정할 수 없습니다.");
+            }
+            diary.incrementPatchCount();
+        } else {
+            diary.updateUpdatedAt(); //수정 날짜 업데이트
+            diary.resetPatchCount(); //수정 횟수 업데이트
         }
     }
 }

--- a/src/main/java/org/sopt/week1/DiaryService.java
+++ b/src/main/java/org/sopt/week1/DiaryService.java
@@ -31,12 +31,18 @@ public class DiaryService {
     }
 
     public void restoreDiary(Long id) {
-        validateExist(id);
+        validateExistInTrash(id);
         diaryRepository.restore(id);
     }
 
     private void validateExist(Long id) {
         if(!diaryRepository.existsById(id)) {
+            throw new InvalidInputException("존재하지 않는 id 값입니다.");
+        }
+    }
+
+    private void validateExistInTrash(Long id) {
+        if(!diaryRepository.existsInTrashById(id)) {
             throw new InvalidInputException("존재하지 않는 id 값입니다.");
         }
     }

--- a/src/main/java/org/sopt/week1/DiaryService.java
+++ b/src/main/java/org/sopt/week1/DiaryService.java
@@ -11,8 +11,7 @@ public class DiaryService {
     private final DiaryRepository diaryRepository = new DiaryRepository();
 
     void postDiary(String body) {
-        final Diary diary = Diary.of(null, body);
-        diaryRepository.save(diary);
+        diaryRepository.save(body);
     }
 
     List<Diary> getDiaryList() {

--- a/src/main/java/org/sopt/week1/Main.java
+++ b/src/main/java/org/sopt/week1/Main.java
@@ -32,6 +32,12 @@ public class Main {
                 super(message);
             }
         }
+
+        class LimitExceededException extends UIException {
+            public LimitExceededException(String message) {
+                super(message);
+            }
+        }
     }
 
     static class DiaryUI implements UI {
@@ -55,7 +61,7 @@ public class Main {
 
                 try {
                     run();
-                } catch (InvalidInputException e) {
+                } catch (InvalidInputException | LimitExceededException e) {
                     ConsoleIO.printLine(e.getMessage());
                 }
 

--- a/src/main/java/org/sopt/week1/Main.java
+++ b/src/main/java/org/sopt/week1/Main.java
@@ -106,6 +106,20 @@ public class Main {
                             server.delete(input);
                         }
 
+                        case "RESTORE" -> {
+                            ConsoleIO.printLine("삭제된 일기 목록");
+                            server.getTrashList().forEach(diary -> {
+                                try {
+                                    ConsoleIO.printLine(diary.getId() + " : " + diary.getBody());
+                                } catch (IOException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+                            ConsoleIO.printLine("복구하고 싶은 일기의 id를 입력하세요!");
+                            final String input = ConsoleIO.readLine();
+                            server.restore(input);
+                        }
+
                         case "FINISH" -> {
                             server.finish();
                         }
@@ -138,6 +152,7 @@ public class Main {
                     - POST : 일기 작성하기
                     - DELETE : 일기 제거하기
                     - PATCH : 일기 수정하기
+                    - RESTORE : 삭제된 일기 복구하기
                     """;
         }
 


### PR DESCRIPTION
## 삭제된 일기를 복구
### 고민 과정
삭제된 일기를 복구하기 위해서는, 기존에 삭제된 일기들을 저장해 둘 공간이 필요하다고 생각했음.
따라서 `private final Map<Long, Diary> trash = new ConcurrentHashMap<>();` 을 만들어, 일기가 삭제될 때, 휴지통에 보관하도록 처리함.
이후 복구 요청이 들어오면, 해당 일기를 휴지통에서 찾아 다시 저장소에 복원할 수 있도록 했음.
휴지통에도 id 값을 저장하여, 복원되면 원래 일기의 id 값으로 저장되도록 했음.

그런데 굳이 새로운 trash 저장소를 만들지 않아도, diary 객체에 isDeleted 필드를 추가하고 storage 저장소에 Diary 객체 자체를 저장하여 soft delete 형식으로 하는 것도 괜찮았을 거란 생각이 듦.
### 구현
``` java
    public void delete(Long id) {
        trash.put(id, storage.get(id));
        storage.remove(id);
    }

    public void restore(Long id) {
        storage.put(id, trash.get(id));
        trash.remove(id);
    }
```
## 일기 수정 하루에 두번만
### 고민 과정
일기를 수정할 때 사용자가 하루에 두 번까지만 수정할 수 있도록 제한하기 위해, 일기 객체에 `patchCount`와 `updatedAt` 필드를 추가
새로운 수정 요청이 들어올 때, 수정 날짜가 현재 날짜와 같으면 patchCount를 증가시키고, 만약 이때 이미 patchCount가 두번이면 "하루에 일기를 2번 이상 수정할 수 없다"는 에러를 날림. 날짜가 다르면 날짜를 갱신하고 patchCount를 초기화

일기 수정 과정에서 storage에 Diary 객체 자체를 저장하는 방법으로 수정
### 구현
```java
    public void patchDiary(Long id, String body) {
        validateExist(id);
        Diary diary = diaryRepository.findById(id);
        updatePatchCountAndDate(diary);
        diary.updateBody(body); //일기 내용 수정
        diaryRepository.patch(id, diary);
    }
```

```java
    private void updatePatchCountAndDate(Diary diary) {
        if (Objects.equals(diary.getUpdatedAt(), LocalDate.now())) { //같은 날 수정하는 경우
            if (diary.getPatchCount() == 2) {
                throw new LimitExceededException("하루에 일기를 2번 이상 수정할 수 없습니다.");
            }
            diary.incrementPatchCount();
        } else {
            diary.updateUpdatedAt(); //수정 날짜 업데이트
            diary.resetPatchCount(); //수정 횟수 업데이트
        }
    }
```
## application이 종료되어도 일기 데이터 유지
### 고민 과정
프로그램이 종료되더라도 일기 데이터를 유지하려면 데이터를 파일에 저장하고, 프로그램이 다시 실행되어도 파일에서 데이터를 불러오는 방식으로 데이터가 손실되지 않게 해야한다고 생각했음. 따라서 JSON 파일 형식으로 데이터를 저장하고 로드하는 방식을 선택함. 
Jackson의 ObjectMapper를 사용하여 Java 객체를 JSON 형식으로 직렬화(Serialization)하여 파일에 저장하고, JSON 파일을 Java 객체로 역직렬화(Deserialization)하여 메모리로 불러오도록 했음

근데 save, patch, delete 매 요청마다 파일 입출력이 발생하게 하는 것보다, 실행 종료 시점에만 데이터를 저장하고, 재실행 시 데이터를 불러오는 방식으로 구현해도 괜찮을 거라는 생각이 듦 (프로그램이 예기치 않게 종료되면 그동안의 변경 사항이 저장되지 않는 문제점이 있을 것 같기도 함)
### 구현
일기 데이터를 `storage.json`, 휴지통 데이터를 `trash.json`, 고유 번호 데이터를 `numbering.json` 파일로 각각 저장
일기 추가, 수정, 삭제 작업이 발생할 때마다 saveDiaries() 및 관련 저장 메서드들이 호출되어 JSON 파일에 변경된 데이터를 즉시 반영
DiaryRepository 생성자는 프로그램 시작 시 저장된 일기와 삭제된 일기, 그리고 고유 ID를 JSON 파일에서 메모리로 불러옴

```java
    public DiaryRepository() {
        objectMapper.registerModule(new JavaTimeModule());
        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
        loadDiaries();
        loadTrash();
        loadNumbering();
    }
```
```java
    private void saveDiaries() {
        try {
            objectMapper.writeValue(new File(STORAGE_FILE), storage);
        } catch (IOException e) {
            e.printStackTrace();
        }
    }

    private void loadDiaries() {
        try {
            Map<Long, Diary> loadedStorage = objectMapper.readValue(new File(STORAGE_FILE), new TypeReference<Map<Long, Diary>>() {});
            storage.putAll(loadedStorage);
        } catch (IOException e) {
            System.out.println("기존 일기 데이터를 불러오지 못했습니다. 새로 시작합니다.");
        }
    }

...
```